### PR TITLE
Fix doc build after mxnet is updated

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /guide/deepnumpy/my_array
 /guide/deepnumpy/my_arrays
 /guide/deepnumpy/.ipynb_checkpoints/cheat-sheet-checkpoint.md
+.idea
+.DS_Store

--- a/api/deepnumpy/routines.io.rst
+++ b/api/deepnumpy/routines.io.rst
@@ -8,11 +8,9 @@ NumPy binary files (NPY, NPZ)
 .. autosummary::
    :toctree: generated/
 
+::
    load
    save
-
-::
-
    savez
    savez_compressed
 

--- a/guide/deepnumpy/cheat-sheet.md
+++ b/guide/deepnumpy/cheat-sheet.md
@@ -68,15 +68,15 @@ np.empty((3,2))  # Create an empty array
 ```{.python .input  n=12}
 # Save one array
 a = np.array([1, 2, 3])
-np.save('my_array', a)
-np.load('my_array')
+npx.save('my_array', a)
+npx.load('my_array')
 ```
 
 ```{.python .input  n=20}
 # Save a list of arrays
 b = np.array([4, 6, 8])
-np.save('my_arrays', [a, b])  # FIXME, cannot be a tuple
-np.load('my_arrays')
+npx.save('my_arrays', [a, b])  # FIXME, cannot be a tuple
+npx.load('my_arrays')
 ```
 
 ### Saving & Loading Text Files

--- a/guide/deepnumpy/deepnumpy-vs-numpy.md
+++ b/guide/deepnumpy/deepnumpy-vs-numpy.md
@@ -81,8 +81,8 @@ The `save` method in `mxnet.np` save data into a binary format that's not compat
 
 ```{.python .input}
 a = np.array(1, ctx=gpu)
-np.save('a', a)
-np.load('a')
+npx.save('a', a)
+npx.load('a')
 ```
 
 ## Matplotlib


### PR DESCRIPTION
Fix doc build after moving `np.save/load` to `npx.save/load`.